### PR TITLE
Add missing requirements for conditional generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,37 @@
 from setuptools import setup, find_packages
 
 setup(
-  name = 'video-diffusion-pytorch',
-  packages = find_packages(exclude=[]),
-  version = '0.6.1',
-  license='MIT',
-  description = 'Video Diffusion - Pytorch',
-  long_description_content_type = 'text/markdown',
-  author = 'Phil Wang',
-  author_email = 'lucidrains@gmail.com',
-  url = 'https://github.com/lucidrains/video-diffusion-pytorch',
-  keywords = [
-    'artificial intelligence',
-    'deep learning',
-    'denoising diffusion probabilistic models',
-    'video generation'
-  ],
-  install_requires=[
-    'einops>=0.4',
-    'einops-exts',
-    'rotary-embedding-torch',
-    'torch>=1.10',
-    'torchvision',
-    'transformers[torch]',
-    'tqdm'
-  ],
-  classifiers=[
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Developers',
-    'Topic :: Scientific/Engineering :: Artificial Intelligence',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.6',
-  ],
+    name='video-diffusion-pytorch',
+    packages=find_packages(exclude=[]),
+    version='0.6.1',
+    license='MIT',
+    description='Video Diffusion - Pytorch',
+    long_description_content_type='text/markdown',
+    author='Phil Wang',
+    author_email='lucidrains@gmail.com',
+    url='https://github.com/lucidrains/video-diffusion-pytorch',
+    keywords=[
+        'artificial intelligence',
+        'deep learning',
+        'denoising diffusion probabilistic models',
+        'video generation'
+    ],
+    install_requires=[
+        'einops>=0.4',
+        'einops-exts',
+        'rotary-embedding-torch',
+        'sacremoses'
+        'sentencepiece',
+        'torch>=1.10',
+        'torchvision',
+        'transformers[torch]',
+        'tqdm'
+    ],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
Adding the missing requirements for when executing the conditional generation with text. I found the missing packages below that were added in `setup.py`. 
I am not sure if the repository requires any specific version for them. Let me know if this is the case. But I tested with their last version and worked fine.

    pip install huggingface-hub
    pip install safetensors
    pip install tokenizers
    pip install sentencepiece
    pip install sacremoses

Obs: I also ran autopep8 at the file.